### PR TITLE
Create the processer for data from GarnBarnAPI in Home page

### DIFF
--- a/src/components/AssignmentBox.vue
+++ b/src/components/AssignmentBox.vue
@@ -19,7 +19,7 @@
 
           <div class="submission-time inline-flex">
             <md-icon>watch_later</md-icon>
-            <p>Submission Time: 19:00</p>
+            <p>Submission Time: {{ timeString }}</p>
           </div>
         </div>
       </md-card-content>
@@ -69,6 +69,17 @@ export default class AssignmentBox extends Vue {
 
   navigateToAssignmentPage(assignmentId: number): void {
     this.$router.push(`/assignment/${assignmentId}`);
+  }
+
+  get timeString(): string {
+    if (typeof this.assignment.dueDate === "undefined") {
+      return "Unknown";
+    }
+    const date = new Date(this.assignment.dueDate);
+    return date.toLocaleTimeString("en-GB", {
+      hour: "numeric",
+      minute: "numeric",
+    });
   }
 }
 </script>

--- a/src/components/DateWithAssignment.vue
+++ b/src/components/DateWithAssignment.vue
@@ -5,7 +5,7 @@
     </div>
     <div class="assignment-list">
       <assignment-box
-        v-for="assignment in assignments"
+        v-for="assignment in assignmentsSorted"
         :key="assignments.indexOf(assignment)"
         :assignment="assignment"
       ></assignment-box>
@@ -24,8 +24,32 @@ import AssignmentBox from "@/components/AssignmentBox.vue";
   },
 })
 export default class DateWithAssignment extends Vue {
-  @Prop({ required: true }) readonly dateString!: string;
+  @Prop({ required: true }) readonly date!: Date;
   @Prop({ default: [] }) readonly assignments!: Array<Assignment>;
+
+  get dateString(): string {
+    return this.date.toLocaleString("en-GB", {
+      day: "numeric",
+      month: "short",
+      year: "numeric",
+    });
+  }
+
+  get assignmentsSorted(): Array<Assignment> {
+    this.assignments.sort((a, b) => {
+      if (
+        typeof a.dueDate === "undefined" ||
+        typeof b.dueDate === "undefined"
+      ) {
+        return -1;
+      }
+      if (a.dueDate < b.dueDate) {
+        return -1;
+      }
+      return 1;
+    });
+    return this.assignments;
+  }
 }
 </script>
 

--- a/src/layouts/Main.vue
+++ b/src/layouts/Main.vue
@@ -3,11 +3,13 @@
     <md-app md-mode="fixed" class="full-height">
       <md-app-toolbar :md-elevation="config.toolBarElevation" class="nav-bar">
         <div class="md-toolbar-row">
-          <div class="logo">GarnBarn</div>
+          <router-link to="/home">
+            <div class="logo">GarnBarn</div>
+          </router-link>
           <div class="itemBar">
             <md-button>Assignment</md-button>
             <md-button>Tag</md-button>
-            <router-link to="account">
+            <router-link to="/account">
               <md-button class="md-icon-button">
                 <md-icon>account_circle</md-icon>
               </md-button>

--- a/src/services/GarnBarnApi/GarnBarnApi.ts
+++ b/src/services/GarnBarnApi/GarnBarnApi.ts
@@ -16,7 +16,7 @@ export default class GarnBarnApi {
    *
    * @returns Instance of v1 initilized with the stored firebaseUser
    */
-  v1(): v1 {
+  get v1(): v1 {
     return new v1(this._firebaseUser);
   }
 }

--- a/src/services/GarnBarnApi/apis/v1/AssignmentApis.ts
+++ b/src/services/GarnBarnApi/apis/v1/AssignmentApis.ts
@@ -37,12 +37,16 @@ export class AssignmentApis extends api {
     fromPresent?: boolean,
     page?: number
   ): Promise<AxiosResponse<BulkApiResponse<Assignment>>> {
-    let url = `${this.API_BASE_URL}/?`;
-    if (typeof page !== "undefined") {
-      url += `page=${page}&`;
-    }
-    if (fromPresent) {
-      url += `fromPresent=true&`;
+    let url = `${this.API_BASE_URL}/`;
+    if (fromPresent || page) {
+      // For adding Query Parameters
+      url += "?";
+      if (page) {
+        url += `page=${page}&`;
+      }
+      if (fromPresent) {
+        url += `fromPresent=true&`;
+      }
     }
     const response = await this.sendRequest("GET", url);
     const responseData = response.data as any;
@@ -62,13 +66,13 @@ export class AssignmentApis extends api {
     url: string | undefined,
     fromPresent?: boolean
   ): GetAllAssignmentApiNextFunctionWrapper | null {
-    if (typeof url === "undefined" || url === null) {
+    if (!url) {
       return null;
     }
     const processedUrl = `?${url?.split("?")[1]}`;
     const urlParams = new URLSearchParams(processedUrl);
     const page = urlParams.get("page");
-    if (typeof page === "undefined" || page === null) {
+    if (!page) {
       return () => {
         return this.all(fromPresent, 1);
       };

--- a/src/services/GarnBarnApi/apis/v1/AssignmentApis.ts
+++ b/src/services/GarnBarnApi/apis/v1/AssignmentApis.ts
@@ -1,8 +1,12 @@
 import { api, ApiSpecError } from "./api";
 import firebase from "firebase";
-import { AxiosPromise, AxiosResponse, AxiosStatic } from "axios";
+import { AxiosResponse, AxiosStatic } from "axios";
 import { AssignmentApi } from "@/types/garnbarn/AssignmentApi";
-
+import { Assignment } from "@/types/garnbarn/Assignment";
+import {
+  BulkApiResponse,
+  GetAllAssignmentApiNextFunctionWrapper,
+} from "@/types/GarnBarnApi/GarnBarnApiResponse";
 export class AssignmentApis extends api {
   API_BASE_URL = "/api/v1/assignment";
   constructor(firebaseUser: firebase.User, axios?: AxiosStatic) {
@@ -15,8 +19,10 @@ export class AssignmentApis extends api {
    *
    * @returns Promise of AxiosResponse for the request in fulfilled state.
    */
-  get(id: number): Promise<AxiosResponse> {
-    return this.sendRequest("GET", `${this.API_BASE_URL}/${id}/`);
+  get(id: number): Promise<AxiosResponse<Assignment>> {
+    return this.sendRequest("GET", `${this.API_BASE_URL}/${id}/`) as Promise<
+      AxiosResponse<Assignment>
+    >;
   }
 
   /**
@@ -25,8 +31,42 @@ export class AssignmentApis extends api {
    *
    * @returns Promise of AxiosResponse for the request in fulfilled state.
    */
-  all(): Promise<AxiosResponse> {
-    return this.sendRequest("GET", `${this.API_BASE_URL}/`);
+  async all(
+    page?: number
+  ): Promise<AxiosResponse<BulkApiResponse<Assignment>>> {
+    let url = `${this.API_BASE_URL}/`;
+    if (typeof page !== "undefined") {
+      url += `?page=${page}`;
+    }
+    const response = await this.sendRequest("GET", url);
+    const responseData = response.data as any;
+    responseData.next = this.createNextMethodForGetAllAssignmentApi(
+      responseData.next
+    );
+    responseData.previous = this.createNextMethodForGetAllAssignmentApi(
+      responseData.previous
+    );
+    response.data = responseData;
+    return response as AxiosResponse<BulkApiResponse<Assignment>>;
+  }
+
+  createNextMethodForGetAllAssignmentApi(
+    url: string | undefined
+  ): GetAllAssignmentApiNextFunctionWrapper | null {
+    if (typeof url === "undefined" || url === null) {
+      return null;
+    }
+    const processedUrl = `?${url?.split("?")[1]}`;
+    const urlParams = new URLSearchParams(processedUrl);
+    const page = urlParams.get("page");
+    if (typeof page === "undefined" || page === null) {
+      return () => {
+        return this.all(1);
+      };
+    }
+    return () => {
+      return this.all(parseInt(page));
+    };
   }
 
   /**
@@ -35,14 +75,18 @@ export class AssignmentApis extends api {
    *
    * @returns Promise of AxiosResponse for the request in fulfilled state.
    */
-  create(assignmentData: AssignmentApi): Promise<AxiosResponse> {
+  create(assignmentData: AssignmentApi): Promise<AxiosResponse<Assignment>> {
     if (typeof assignmentData.id !== "undefined") {
       throw new ApiSpecError("You can't set the assignment id");
     }
     if (typeof assignmentData.name === "undefined") {
       throw new ApiSpecError("You can't create an assignment without a name");
     }
-    return this.sendRequest("POST", `${this.API_BASE_URL}/`, assignmentData);
+    return this.sendRequest(
+      "POST",
+      `${this.API_BASE_URL}/`,
+      assignmentData
+    ) as Promise<AxiosResponse<Assignment>>;
   }
 
   /**
@@ -51,11 +95,18 @@ export class AssignmentApis extends api {
    *
    * @returns Promise of AxiosResponse for the request in fulfilled state.
    */
-  update(id: number, updateField: AssignmentApi): Promise<AxiosResponse> {
+  update(
+    id: number,
+    updateField: AssignmentApi
+  ): Promise<AxiosResponse<Assignment>> {
     if (typeof updateField.id !== "undefined") {
       throw new ApiSpecError("You can't update the assignment id");
     }
-    return this.sendRequest("PATCH", `${this.API_BASE_URL}/${id}/`, updateField);
+    return this.sendRequest(
+      "PATCH",
+      `${this.API_BASE_URL}/${id}/`,
+      updateField
+    ) as Promise<AxiosResponse<Assignment>>;
   }
 
   /**

--- a/src/services/GarnBarnApi/apis/v1/AssignmentApis.ts
+++ b/src/services/GarnBarnApi/apis/v1/AssignmentApis.ts
@@ -29,29 +29,38 @@ export class AssignmentApis extends api {
    * Call Get All Assignments API
    * https://garnbarn.github.io/garnbarn-backend/#/api?id=create-assignment
    *
-   * @returns Promise of AxiosResponse for the request in fulfilled state.
+   * @param fromPresent Get the assignment only from today.
+   * @param page Page that API assigned to call.
+   * @returns Promise of AxiosResponse that contain BlukApiResponse of Assignment as data
    */
   async all(
+    fromPresent?: boolean,
     page?: number
   ): Promise<AxiosResponse<BulkApiResponse<Assignment>>> {
-    let url = `${this.API_BASE_URL}/`;
+    let url = `${this.API_BASE_URL}/?`;
     if (typeof page !== "undefined") {
-      url += `?page=${page}`;
+      url += `page=${page}&`;
+    }
+    if (fromPresent) {
+      url += `fromPresent=true&`;
     }
     const response = await this.sendRequest("GET", url);
     const responseData = response.data as any;
     responseData.next = this.createNextMethodForGetAllAssignmentApi(
-      responseData.next
+      responseData.next,
+      fromPresent
     );
     responseData.previous = this.createNextMethodForGetAllAssignmentApi(
-      responseData.previous
+      responseData.previous,
+      fromPresent
     );
     response.data = responseData;
     return response as AxiosResponse<BulkApiResponse<Assignment>>;
   }
 
   createNextMethodForGetAllAssignmentApi(
-    url: string | undefined
+    url: string | undefined,
+    fromPresent?: boolean
   ): GetAllAssignmentApiNextFunctionWrapper | null {
     if (typeof url === "undefined" || url === null) {
       return null;
@@ -61,11 +70,11 @@ export class AssignmentApis extends api {
     const page = urlParams.get("page");
     if (typeof page === "undefined" || page === null) {
       return () => {
-        return this.all(1);
+        return this.all(fromPresent, 1);
       };
     }
     return () => {
-      return this.all(parseInt(page));
+      return this.all(fromPresent, parseInt(page));
     };
   }
 

--- a/src/services/GarnBarnApi/apis/v1/AssignmentApis.ts
+++ b/src/services/GarnBarnApi/apis/v1/AssignmentApis.ts
@@ -89,10 +89,10 @@ export class AssignmentApis extends api {
    * @returns Promise of AxiosResponse for the request in fulfilled state.
    */
   create(assignmentData: AssignmentApi): Promise<AxiosResponse<Assignment>> {
-    if (typeof assignmentData.id !== "undefined") {
+    if (assignmentData.id) {
       throw new ApiSpecError("You can't set the assignment id");
     }
-    if (typeof assignmentData.name === "undefined") {
+    if (!assignmentData.name) {
       throw new ApiSpecError("You can't create an assignment without a name");
     }
     return this.sendRequest(
@@ -112,7 +112,7 @@ export class AssignmentApis extends api {
     id: number,
     updateField: AssignmentApi
   ): Promise<AxiosResponse<Assignment>> {
-    if (typeof updateField.id !== "undefined") {
+    if (updateField.id) {
       throw new ApiSpecError("You can't update the assignment id");
     }
     return this.sendRequest(

--- a/src/services/GarnBarnApi/apis/v1/AssignmentApis.ts
+++ b/src/services/GarnBarnApi/apis/v1/AssignmentApis.ts
@@ -27,7 +27,7 @@ export class AssignmentApis extends api {
 
   /**
    * Call Get All Assignments API
-   * https://garnbarn.github.io/garnbarn-backend/#/api?id=create-assignment
+   * https://garnbarn.github.io/garnbarn-backend/#/api?id=get-all-assignments
    *
    * @param fromPresent Get the assignment only from today.
    * @param page Page that API assigned to call.

--- a/src/services/GarnBarnApi/apis/v1/v1.ts
+++ b/src/services/GarnBarnApi/apis/v1/v1.ts
@@ -17,7 +17,7 @@ export class v1 {
    *
    * @returns Instance of AssignmentApis
    */
-  assignment(): AssignmentApis {
+  get assignments(): AssignmentApis {
     return new AssignmentApis(this._firebaseUser, this._axiosInstance);
   }
 }

--- a/src/types/GarnBarnApi/GarnBarnApiResponse.ts
+++ b/src/types/GarnBarnApi/GarnBarnApiResponse.ts
@@ -1,0 +1,12 @@
+import { AssignmentApis } from "@/services/GarnBarnApi/apis/v1/AssignmentApis";
+
+export type BulkApiResponse<R = any> = {
+  count: number;
+  next: GetAllAssignmentApiNextFunctionWrapper | null;
+  previous: GetAllAssignmentApiNextFunctionWrapper | null;
+  results: Array<R>;
+};
+
+export type GetAllAssignmentApiNextFunctionWrapper = () => ReturnType<
+  AssignmentApis["all"]
+>;

--- a/src/types/garnbarn/Assignment.ts
+++ b/src/types/garnbarn/Assignment.ts
@@ -10,7 +10,7 @@ export type Assignment = {
 };
 
 export type AssignmentsInDay = {
-  date: string;
+  date: Date;
   assignments: Array<Assignment>;
 };
 

--- a/src/views/Assignment.vue
+++ b/src/views/Assignment.vue
@@ -110,10 +110,9 @@ export default class AssignmentView extends Vue {
 
   async get(): Promise<void> {
     try {
-      const apiResponse = await this.garnBarnAPICaller
-        ?.v1()
-        .assignment()
-        .get(this.assignmentId);
+      const apiResponse = await this.garnBarnAPICaller?.v1.assignments.get(
+        this.assignmentId
+      );
       this.assignment = apiResponse?.data as Assignment;
     } catch (e) {
       this.informDialogBox.show({
@@ -131,9 +130,7 @@ export default class AssignmentView extends Vue {
       assignmentCopy,
       this.assignmentEdit.cachedAssignment
     );
-    this.garnBarnAPICaller
-      ?.v1()
-      .assignment()
+    this.garnBarnAPICaller?.v1.assignments
       .update(this.assignmentId, diff)
       .then((apiResponse) => {
         this.assignment = apiResponse.data as Assignment;

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,13 +1,23 @@
 <template>
   <layout :callback="callback">
     <div v-if="!callApiError.isError">
-      <DateWithAssignment
-        v-for="assignmentInDay in assignments.dateWithAssignments"
-        :key="assignments.dateWithAssignments.indexOf(assignmentInDay)"
-        :dateString="assignmentInDay.date"
-        :assignments="assignmentInDay.assignments"
-      ></DateWithAssignment>
+      <div v-if="assignments.dateWithAssignments.length !== 0">
+        <DateWithAssignment
+          v-for="assignmentInDay in assignments.dateWithAssignments"
+          :key="assignments.dateWithAssignments.indexOf(assignmentInDay)"
+          :date="assignmentInDay.date"
+          :assignments="assignmentInDay.assignments"
+        ></DateWithAssignment>
+      </div>
+      <md-empty-state
+        md-icon="inventory_2"
+        md-label="There is no assignment left!"
+        md-description="Horry!, No work left. Or ya hide someting?"
+        v-else
+      >
+      </md-empty-state>
     </div>
+
     <md-empty-state
       class="md-accent"
       md-icon="error_outline"
@@ -108,13 +118,15 @@ export default class Home extends Vue {
       const dateTitle = dueDate.toLocaleString("en-GB", {
         day: "numeric",
         month: "short",
+        year: "numeric",
       });
-      if (!(dateTitle in mapDateWithPos)) {
+      if (typeof mapDateWithPos[dateTitle] === "undefined") {
         // If no date found before, Append the new one
-        cacheDatewithAssignment.dateWithAssignments.push({
-          date: dateTitle,
+        const pos = cacheDatewithAssignment.dateWithAssignments.push({
+          date: dueDate,
           assignments: [item],
         });
+        mapDateWithPos[dateTitle] = pos - 1;
       } else {
         const posOfDate = mapDateWithPos[dateTitle];
         cacheDatewithAssignment.dateWithAssignments[posOfDate].assignments.push(
@@ -122,6 +134,9 @@ export default class Home extends Vue {
         );
       }
     });
+    cacheDatewithAssignment.dateWithAssignments.sort((a, b) =>
+      a.date > b.date ? 1 : -1
+    );
     return cacheDatewithAssignment;
   }
 }

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -61,14 +61,10 @@ export default class Home extends Vue {
     this.get(loadingDialogBox);
   }
   async get(loadingDialogBox: DialogBox) {
-    this.garnBarnAPICaller
-      ?.v1()
-      .assignment()
+    this.garnBarnAPICaller?.v1.assignments
       .all()
-      .then((apiResponse) => {
-        this.assignments = this.processData(
-          (apiResponse.data as any).results as Array<Assignment>
-        );
+      .then(async (apiResponse) => {
+        this.assignments = this.processData(apiResponse.data.results);
         loadingDialogBox.dismiss();
       })
       .catch((e) => {

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,11 +1,21 @@
 <template>
   <layout :callback="callback">
-    <DateWithAssignment
-      v-for="assignmentInDay in assignments.dateWithAssignments"
-      :key="assignments.dateWithAssignments.indexOf(assignmentInDay)"
-      :dateString="assignmentInDay.date"
-      :assignments="assignmentInDay.assignments"
-    ></DateWithAssignment>
+    <div v-if="!callApiError.isError">
+      <DateWithAssignment
+        v-for="assignmentInDay in assignments.dateWithAssignments"
+        :key="assignments.dateWithAssignments.indexOf(assignmentInDay)"
+        :dateString="assignmentInDay.date"
+        :assignments="assignmentInDay.assignments"
+      ></DateWithAssignment>
+    </div>
+    <md-empty-state
+      class="md-accent"
+      md-icon="error_outline"
+      md-label="An Error occurred while calling GarnBarn API"
+      :md-description="callApiError.errorMessage"
+      v-else
+    >
+    </md-empty-state>
   </layout>
 </template>
 
@@ -13,7 +23,7 @@
 import Layout from "@/layouts/Main.vue";
 import DateWithAssignment from "@/components/DateWithAssignment.vue";
 import { Component, Vue } from "vue-property-decorator";
-import { DateWithAssignments } from "@/types/garnbarn/Assignment";
+import { Assignment, DateWithAssignments } from "@/types/garnbarn/Assignment";
 import GarnBarnApi from "@/services/GarnBarnApi/GarnBarnApi";
 import DialogBox from "@/components/DialogBox/DialogBox";
 import firebase from "firebase";
@@ -27,89 +37,92 @@ import firebase from "firebase";
 export default class Home extends Vue {
   garnBarnAPICaller: GarnBarnApi | undefined = undefined;
   informDialogBox = new DialogBox("informDialogBox");
+  loadingDialogBox = new DialogBox("loadingDialogBox");
   assignments: DateWithAssignments = {
-    dateWithAssignments: [
-      {
-        date: "12 Sep.",
-        assignments: [
-          {
-            id: 1,
-            name: "Test 1",
-            tag: {
-              id: 1,
-              name: "Test Tag",
-              color: "#30475E",
-            },
-          },
-          {
-            id: 2,
-            name: "Test 2",
-            tag: {
-              id: 2,
-              name: "Tag 2",
-              color: "#ff9e59",
-            },
-          },
-        ],
-      },
-      {
-        date: "20 Oct.",
-        assignments: [
-          {
-            id: 3,
-            name: "Test 3",
-            tag: {
-              id: 3,
-              name: "Tag 3",
-              color: "#ffbf59",
-            },
-          },
-        ],
-      },
-      {
-        date: "30 Oct.",
-        assignments: [
-          {
-            id: 4,
-            name: "Test 4",
-            tag: {
-              id: 3,
-              name: "Tag 3",
-              color: "#CBAF87",
-            },
-          },
-          {
-            id: 5,
-            name: "Test 5",
-          },
-          {
-            id: 6,
-            name: "Test 6",
-          },
-          {
-            id: 7,
-            name: "Test 7",
-          },
-        ],
-      },
-    ],
+    dateWithAssignments: [],
   };
+  callApiError = {
+    isError: false,
+    errorMessage: "",
+  };
+
   callback(user: firebase.User, loadingDialogBox: DialogBox) {
     this.garnBarnAPICaller = new GarnBarnApi(user);
     this.get(loadingDialogBox);
   }
   async get(loadingDialogBox: DialogBox) {
-    try {
-      const apiResponse = await this.garnBarnAPICaller?.v1().assignment().all();
-    } catch (e) {
-      this.informDialogBox.show({
-        dialogBoxContent: {
-          title: "Error",
-          content: `Can't fetch data from GarnBarn API, Please try again or contact Administrator.`,
-        },
+    this.garnBarnAPICaller
+      ?.v1()
+      .assignment()
+      .all()
+      .then((apiResponse) => {
+        this.assignments = this.processData(
+          (apiResponse.data as any).results as Array<Assignment>
+        );
+        loadingDialogBox.dismiss();
+      })
+      .catch((e) => {
+        console.error(e);
+        this.informDialogBox.show({
+          dialogBoxContent: {
+            title: "Error",
+            content: `Can't fetch data from GarnBarn API, Please try again or contact Administrator.`,
+          },
+          dialogBoxActions: [
+            {
+              buttonContent: "Try again",
+              buttonClass: "md-primary",
+              onClick: async () => {
+                await this.informDialogBox.dismiss();
+                this.get(loadingDialogBox);
+              },
+            },
+            {
+              buttonContent: "Dismiss",
+              buttonClass: "md-secondary",
+              onClick: async () => {
+                this.callApiError.isError = true;
+                this.callApiError.errorMessage = e;
+                await loadingDialogBox.dismiss();
+                this.informDialogBox.dismiss();
+              },
+            },
+          ],
+        });
       });
-    }
-    loadingDialogBox.dismiss();
+  }
+
+  processData(assignments: Array<Assignment>): DateWithAssignments {
+    type mapPosWithData = {
+      [k: string]: number;
+    };
+    const mapDateWithPos: mapPosWithData = {};
+    const cacheDatewithAssignment: DateWithAssignments = {
+      dateWithAssignments: [],
+    };
+    assignments.forEach((item) => {
+      if (!item.dueDate) {
+        return;
+      }
+      const dueDate = new Date(item.dueDate);
+      const dateTitle = dueDate.toLocaleString("en-GB", {
+        day: "numeric",
+        month: "short",
+      });
+      if (!(dateTitle in mapDateWithPos)) {
+        // If no date found before, Append the new one
+        cacheDatewithAssignment.dateWithAssignments.push({
+          date: dateTitle,
+          assignments: [item],
+        });
+      } else {
+        const posOfDate = mapDateWithPos[dateTitle];
+        cacheDatewithAssignment.dateWithAssignments[posOfDate].assignments.push(
+          item
+        );
+      }
+    });
+    return cacheDatewithAssignment;
   }
 }
 </script>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -62,7 +62,7 @@ export default class Home extends Vue {
   }
   async get(loadingDialogBox: DialogBox) {
     this.garnBarnAPICaller?.v1.assignments
-      .all()
+      .all(true)
       .then(async (apiResponse) => {
         this.assignments = this.processData(apiResponse.data.results);
         loadingDialogBox.dismiss();

--- a/tests/unit/GarnBarnApiCaller/v1/AssignmentApisCaller.spec.ts
+++ b/tests/unit/GarnBarnApiCaller/v1/AssignmentApisCaller.spec.ts
@@ -77,7 +77,7 @@ describe("Test Assignment APIs v1 Caller", () => {
   });
 
   test("Test calling Get Assignment API with valid data", async () => {
-    const apiResponse = await garnBarnApiCaller.v1().assignment().get(1);
+    const apiResponse = await garnBarnApiCaller.v1.assignments.get(1);
     expect(mockAxios).toHaveBeenCalledWith(
       generateRequestDetail(ID_TOKEN, "GET", "/api/v1/assignment/1/")
     );
@@ -91,10 +91,9 @@ describe("Test Assignment APIs v1 Caller", () => {
       dueDate: 1634745493,
       tagId: 1,
     };
-    const apiResponse = await garnBarnApiCaller
-      .v1()
-      .assignment()
-      .create(mockAssignmentData);
+    const apiResponse = await garnBarnApiCaller.v1.assignments.create(
+      mockAssignmentData
+    );
     expect(mockAxios).toBeCalledWith(
       generateRequestDetail(
         ID_TOKEN,
@@ -116,7 +115,7 @@ describe("Test Assignment APIs v1 Caller", () => {
     };
     // User can't set the assignment id and the api caller must throw the ApiSpecError
     expect(() => {
-      garnBarnApiCaller.v1().assignment().create(mockAssignmentData);
+      garnBarnApiCaller.v1.assignments.create(mockAssignmentData);
     }).toThrow(new ApiSpecError("You can't set the assignment id"));
   });
 
@@ -127,7 +126,7 @@ describe("Test Assignment APIs v1 Caller", () => {
       tagId: 1,
     };
     expect(() => {
-      garnBarnApiCaller.v1().assignment().create(mockAssignmentData);
+      garnBarnApiCaller.v1.assignments.create(mockAssignmentData);
     }).toThrow(
       new ApiSpecError("You can't create an assignment without a name")
     );
@@ -143,10 +142,10 @@ describe("Test Assignment APIs v1 Caller", () => {
     mockAxios.mockResolvedValue({
       data: generateAssignmentObject(MOCK_RESPONSE, mockAssignmentApiData),
     });
-    const apiResponse = await garnBarnApiCaller
-      .v1()
-      .assignment()
-      .update(1, mockAssignmentApiData);
+    const apiResponse = await garnBarnApiCaller.v1.assignments.update(
+      1,
+      mockAssignmentApiData
+    );
     expect(mockAxios).toBeCalledWith(
       generateRequestDetail(
         ID_TOKEN,
@@ -170,7 +169,7 @@ describe("Test Assignment APIs v1 Caller", () => {
     };
 
     expect(() => {
-      garnBarnApiCaller.v1().assignment().update(1, mockAssignmentApiData);
+      garnBarnApiCaller.v1.assignments.update(1, mockAssignmentApiData);
     }).toThrow(new ApiSpecError("You can't update the assignment id"));
   });
 
@@ -179,7 +178,7 @@ describe("Test Assignment APIs v1 Caller", () => {
       data: {},
     });
 
-    const apiResponse = await garnBarnApiCaller.v1().assignment().delete(1);
+    const apiResponse = await garnBarnApiCaller.v1.assignments.delete(1);
     expect(mockAxios).toBeCalledWith(
       generateRequestDetail(ID_TOKEN, "DELETE", "/api/v1/assignment/1/")
     );
@@ -211,7 +210,7 @@ describe("Test Assignment APIs v1 Caller", () => {
       ],
     };
     mockAxios.mockResolvedValue({ data: mockResponse });
-    const apiResponse = await garnBarnApiCaller.v1().assignment().all();
+    const apiResponse = await garnBarnApiCaller.v1.assignments.all();
     expect(mockAxios).toBeCalledWith(
       generateRequestDetail(ID_TOKEN, "GET", "/api/v1/assignment/")
     );


### PR DESCRIPTION
Add Processer for data and make the GarnBarn API Module also return type instead of any.

## PR Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Others. (Please describe)

## PR Info.

### Changes

1. Add Processor for data from GarnBarn API on home page
2. Make the GarnBarn API Caller module return the type and make the get all assignment API caller to process all method and return the function to call next instead of a string of URL
3. Implement the next method handler on Home Page and make the button appear when there is some page left to get assignments.
4. Make clicking on the GarnBarn logo redirect the user to the home page

### Fixes

 1. Fix the bug when the user clicks on the user icon on the child path, It redirects to the wrong path (Ex: `/assignment/1` - [After click] ->  `assignment/1/account`).

